### PR TITLE
Add support for sending contextual_update events

### DIFF
--- a/Sources/ElevenLabsSwift/ElevenLabsSwift.swift
+++ b/Sources/ElevenLabsSwift/ElevenLabsSwift.swift
@@ -1213,6 +1213,15 @@ public class ElevenLabsSDK {
             callbacks.onStatusChange(newStatus)
         }
 
+        /// Send a contextual update event
+        public func sendContextualUpdate(_ text: String) {
+            let event: [String: Any] = [
+                "type": "contextual_update",
+                "text": text
+            ]
+            sendWebSocketMessage(event)
+        }
+
         /// Ends the current conversation session
         public func endSession() {
             guard status == .connected else { return }


### PR DESCRIPTION
A trivial addition in order to support [contextual_update](https://elevenlabs.io/docs/conversational-ai/customization/events/client-to-server-events#contextual-updates) events.

P.S. This also a problem in the Python SDK